### PR TITLE
Improve chart browsing and visualization

### DIFF
--- a/netdata/Modules/ServerDetail/Components/AlarmListRow.swift
+++ b/netdata/Modules/ServerDetail/Components/AlarmListRow.swift
@@ -11,13 +11,13 @@ struct AlarmListRow: View {
     var alarm: ServerAlarm;
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 6) {
             Text(alarm.status ?? "UNKNOWN")
                 .font(.caption)
                 .bold()
                 .foregroundColor(self.isCritical() ? Color.red : Color.orange)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
                 .background(RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .foregroundColor((self.isCritical() ? Color.red : Color.orange).opacity(0.1)))
 
@@ -33,7 +33,6 @@ struct AlarmListRow: View {
                     .foregroundColor(.gray)
             }
         }
-        .padding(8)
     }
     
     func isCritical() -> Bool {

--- a/netdata/Modules/ServerDetail/Components/ChartListRow.swift
+++ b/netdata/Modules/ServerDetail/Components/ChartListRow.swift
@@ -16,14 +16,33 @@ struct ChartListRow: View {
         NavigationLink(destination: CustomChartDetailView(serverChart: chart,
                                                           serverUrl: serverUrl,
                                                           basicAuthBase64: basicAuthBase64)) {
-            VStack(alignment: .leading, spacing: 10) {
-                HStack {
-                    Text("\(chart.name) - \(chart.family)")
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(chart.name)
                         .font(.headline)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Text(chart.units)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.quaternary, in: Capsule())
                 }
                 
                 Text(chart.title)
                     .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                HStack(spacing: 6) {
+                    Text(chart.family)
+                    Text(chart.type)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
             .padding(.vertical, 8)
         }

--- a/netdata/Modules/ServerDetail/Components/ChartListRow.swift
+++ b/netdata/Modules/ServerDetail/Components/ChartListRow.swift
@@ -16,7 +16,7 @@ struct ChartListRow: View {
         NavigationLink(destination: CustomChartDetailView(serverChart: chart,
                                                           serverUrl: serverUrl,
                                                           basicAuthBase64: basicAuthBase64)) {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 5) {
                 HStack(alignment: .firstTextBaseline) {
                     Text(chart.name)
                         .font(.headline)
@@ -28,7 +28,7 @@ struct ChartListRow: View {
                         .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
+                        .padding(.vertical, 2)
                         .background(.quaternary, in: Capsule())
                 }
                 
@@ -44,7 +44,6 @@ struct ChartListRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             }
-            .padding(.vertical, 8)
         }
     }
 }

--- a/netdata/Modules/ServerDetail/Components/ChartsListView.swift
+++ b/netdata/Modules/ServerDetail/Components/ChartsListView.swift
@@ -56,8 +56,13 @@ struct ChartsListView: View {
             return charts.activeCharts
         }
         
-        return charts.activeCharts.filter {
-            $0.name.lowercased().contains(searchText.lowercased())
+        return charts.activeCharts.filter { chart in
+            let query = searchText.lowercased()
+            return chart.name.lowercased().contains(query) ||
+                chart.title.lowercased().contains(query) ||
+                chart.family.lowercased().contains(query) ||
+                chart.context.lowercased().contains(query) ||
+                chart.units.lowercased().contains(query)
         }
     }
     

--- a/netdata/Modules/ServerDetail/Components/CustomChartDetailView.swift
+++ b/netdata/Modules/ServerDetail/Components/CustomChartDetailView.swift
@@ -25,7 +25,24 @@ struct CustomChartDetailView: View {
     
     var body: some View {
         List {
-            Section("\(serverChart.name) (\(units()))") {
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(serverChart.title)
+                            .font(.headline)
+                        Text("\(serverChart.family) · \(units())")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    ChartView(data: chartData)
+                        .frame(height: 260)
+                }
+                .padding(.vertical, 8)
+            }
+            .readableGuidePadding()
+
+            Section("Latest values") {
                 DataGrid(labels: chartData.labels,
                          data: chartData.data,
                          dataType: self.getDataType(),

--- a/netdata/Modules/ServerDetail/Components/CustomChartDetailView.swift
+++ b/netdata/Modules/ServerDetail/Components/CustomChartDetailView.swift
@@ -25,24 +25,7 @@ struct CustomChartDetailView: View {
     
     var body: some View {
         List {
-            Section {
-                VStack(alignment: .leading, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(serverChart.title)
-                            .font(.headline)
-                        Text("\(serverChart.family) · \(units())")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    ChartView(data: chartData)
-                        .frame(height: 260)
-                }
-                .padding(.vertical, 8)
-            }
-            .readableGuidePadding()
-
-            Section("Latest values") {
+            Section("\(serverChart.name) (\(units()))") {
                 DataGrid(labels: chartData.labels,
                          data: chartData.data,
                          dataType: self.getDataType(),

--- a/netdata/Modules/ServerDetail/ServerDetailView.swift
+++ b/netdata/Modules/ServerDetail/ServerDetailView.swift
@@ -19,6 +19,14 @@ struct ServerDetailView: View {
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
+                Picker("Time range", selection: $viewModel.dataMode) {
+                    Text("Current").tag(DataMode.now)
+                    Text("Last 15 min").tag(DataMode.fifteenMins)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
                 LazyVGrid(columns: gridLayout(for: geometry.size.width), alignment: .leading, spacing: 12) {
                     RedactedView(loading: viewModel.cpuUsage.labels.count < 1) {
                         ServerDetailItem(label: "CPU Usage (%)") {
@@ -205,14 +213,8 @@ struct ServerDetailView: View {
         }
         .navigationBarTitle(server.name)
         .toolbar {
-            ToolbarItemGroup(placement: .navigation) {
+            ToolbarItem(placement: .navigation) {
                 PulsatingView(live: viewModel.isLive)
-                
-                Picker("Data mode", selection: $viewModel.dataMode) {
-                    Text("Now").tag(DataMode.now)
-                    Text("15 Mins").tag(DataMode.fifteenMins)
-                }
-                .pickerStyle(.segmented)
             }
             
             ToolbarItemGroup(placement: .bottomBar) {
@@ -227,7 +229,7 @@ struct ServerDetailView: View {
                 
                 NavigationLink(destination: AlarmsListView(serverUrl: server.url, basicAuthBase64: server.basicAuthBase64)) {
                     HStack {
-                        Image(systemName: "alarm")
+                        Image(systemName: "exclamationmark.triangle.fill")
                         Text("Alarms")
                     }
                 }
@@ -251,4 +253,3 @@ struct ServerDetailView: View {
         return Array(repeating: .init(.flexible(), alignment: .topLeading), count: max(numberOfColumns, 1)) // Ensuring at least one column
     }
 }
-

--- a/netdata/Modules/Shared/UI/ChartView.swift
+++ b/netdata/Modules/Shared/UI/ChartView.swift
@@ -5,7 +5,7 @@ struct ChartDataPoint: Identifiable {
     let id = UUID()
     var label: String
     var value: Double
-    var time: String
+    var time: Date
 }
 
 struct ChartView: View {
@@ -14,15 +14,49 @@ struct ChartView: View {
     var body: some View {
         let chartData = prepareChartData(serverData: data)
         
-        Chart {
-            ForEach(chartData) { dataPoint in
-                LineMark(
-                    x: .value("Time", dataPoint.time),
-                    y: .value(dataPoint.label, dataPoint.value)
-                )
-                .foregroundStyle(by: .value("Label", dataPoint.label))
-                .interpolationMethod(.catmullRom)
+        if chartData.isEmpty {
+            VStack(spacing: 8) {
+                Image(systemName: "chart.xyaxis.line")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                Text("Waiting for chart data")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
             }
+            .frame(maxWidth: .infinity, minHeight: 140)
+        } else {
+            Chart {
+                ForEach(chartData) { dataPoint in
+                    LineMark(
+                        x: .value("Time", dataPoint.time),
+                        y: .value(dataPoint.label, dataPoint.value)
+                    )
+                    .foregroundStyle(by: .value("Series", dataPoint.label))
+                    .lineStyle(.init(lineWidth: 2, lineCap: .round, lineJoin: .round))
+                    .interpolationMethod(.catmullRom)
+                }
+            }
+            .chartLegend(position: .bottom, alignment: .leading, spacing: 8)
+            .chartXAxis {
+                AxisMarks(values: .automatic(desiredCount: 4)) {
+                    AxisGridLine()
+                    AxisTick()
+                    AxisValueLabel(format: .dateTime.hour().minute())
+                }
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading, values: .automatic(desiredCount: 4)) {
+                    AxisGridLine()
+                    AxisTick()
+                    AxisValueLabel()
+                }
+            }
+            .chartPlotStyle { plotArea in
+                plotArea
+                    .background(.quaternary.opacity(0.35))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .padding(.top, 8)
         }
     }
     
@@ -39,14 +73,13 @@ struct ChartView: View {
                             label: label,
                             value: value,
                             time: Date(timeIntervalSince1970: time)
-                                .formatted(.dateTime.minute().second())
                         )
                     )
                 }
             }
         }
         
-        return chartData.reversed()
+        return Array(chartData.reversed())
     }
 }
 


### PR DESCRIPTION
## Summary
- improve chart list rows with clearer names, titles, metadata, and unit badges
- expand chart search to include title, family, context, and units
- polish shared charts with date-based axes, legends, grid lines, and an empty-data state
- keep custom chart details focused on live latest values
- move the dashboard time-range selector above the grid and clarify its labels
- use a warning symbol for the Alarms action

## Testing
- `xcodebuild build -project netdata.xcodeproj -scheme netdata -configuration Debug -destination 'platform=iOS Simulator,id=5E4CF6FB-9C75-4904-9B10-7A6875EED233'`